### PR TITLE
Revert "bump version to 1.1.12 for release"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'groovy'
 
 group = 'com.ibm.security'
-version = '1.1.12'
+version = '1.1.11'
 
 dependencies {
     implementation gradleApi()


### PR DESCRIPTION
Reverts HCL-TECH-SOFTWARE/appscan-source-gradle-plugin#28
Código abierto 