### PR TITLE
AS-2886: AppScan Source default installation path change 

### DIFF
--- a/src/main/groovy/com/ibm/appscan/gradle/settings/AppScanSettingsExtension.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/settings/AppScanSettingsExtension.groovy
@@ -49,16 +49,16 @@ public class AppScanSettingsExtension implements AppScanConstants {
 	private void setAppScanDirs() {
 		String osName = System.getProperty("os.name").toLowerCase()
 		if(osName.contains("windows")) {
-			installdir = System.getProperty(INSTALL) ?: new File("C:/Program Files (x86)/IBM/AppScanSource/bin/AppScanSrcCli.exe").exists() ? "C:/Program Files (x86)/IBM/AppScanSource" : "C:/Program Files/HCL/AppScanSource"
-			configdir = new File("C:/ProgramData/IBM/AppScanSource/config").exists() ? "C:/ProgramData/IBM/AppScanSource" : "C:/ProgramData/HCL/AppScanSource"
+			installdir = System.getProperty(INSTALL) ?: new File("C:/Program Files/HCL/AppScanSource").exists() ? "C:/Program Files/HCL/AppScanSource" : "C:/Program Files (x86)/IBM/AppScanSource"
+			configdir = new File("C:/ProgramData/HCL/AppScanSource").exists() ? "C:/ProgramData/HCL/AppScanSource" : "C:/ProgramData/IBM/AppScanSource"
 		}
 		else if(osName.contains("mac")) {
 			installdir = System.getProperty(INSTALL) ?: "/Applications/AppScanSource.app"
 			configdir = "/Users/Shared/AppScanSource"	
 		}
 		else {
-			installdir = System.getProperty(INSTALL) ?: new File("/opt/ibm/appscansource/bin/appscansrccli").exists() ? "/opt/ibm/appscansource" : "/opt/hcl/appscansource"
-			configdir = new File("/var/opt/ibm/appscansource/config").exists() ? "/var/opt/ibm/appscansource" : "/var/opt/hcl/appscansource"
+			installdir = System.getProperty(INSTALL) ?: new File("/opt/hcl/appscansource").exists() ? "/opt/hcl/appscansource" : "/opt/ibm/appscansource"
+			configdir = new File("/var/opt/hcl/appscansource").exists() ? "/var/opt/hcl/appscansource" : "/var/opt/ibm/appscansource"
 		}
 	}
 }

--- a/src/main/groovy/com/ibm/appscan/gradle/settings/AppScanSettingsExtension.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/settings/AppScanSettingsExtension.groovy
@@ -49,16 +49,16 @@ public class AppScanSettingsExtension implements AppScanConstants {
 	private void setAppScanDirs() {
 		String osName = System.getProperty("os.name").toLowerCase()
 		if(osName.contains("windows")) {
-			installdir = System.getProperty(INSTALL) ?: "C:/Program Files (x86)/IBM/AppScanSource"
-			configdir = "C:/ProgramData/IBM/AppScanSource"	
+			installdir = System.getProperty(INSTALL) ?: new File("C:/Program Files (x86)/IBM/AppScanSource/bin/AppScanSrcCli.exe").exists() ? "C:/Program Files (x86)/IBM/AppScanSource" : "C:/Program Files/HCL/AppScanSource"
+			configdir = new File("C:/ProgramData/IBM/AppScanSource/config").exists() ? "C:/ProgramData/IBM/AppScanSource" : "C:/ProgramData/HCL/AppScanSource"
 		}
 		else if(osName.contains("mac")) {
 			installdir = System.getProperty(INSTALL) ?: "/Applications/AppScanSource.app"
 			configdir = "/Users/Shared/AppScanSource"	
 		}
 		else {
-			installdir = System.getProperty(INSTALL) ?: "/opt/ibm/appscansource"
-			configdir = "/var/opt/ibm/appscansource"	
+			installdir = System.getProperty(INSTALL) ?: new File("/opt/ibm/appscansource/bin/appscansrccli").exists() ? "/opt/ibm/appscansource" : "/opt/hcl/appscansource"
+			configdir = new File("/var/opt/ibm/appscansource/config").exists() ? "/var/opt/ibm/appscansource" : "/var/opt/hcl/appscansource"
 		}
 	}
 }


### PR DESCRIPTION
@mattmurp 

**Issue:**
As you are aware, AppScan Source is upgrading to use IBM Semeru JDK/JRE  and the Product path has also been changed from IBM to HCL so the new installation path would be **C:/Program Files/HCL/AppScanSource** but the install dir path is hardcoded to use IBM default installation path hence appscan gradle cmd fails 

**Fix:**
Code changes are first, it checks for the IBM default installation path if it doesn't exist then it will look for the HCL default installation path.

**Tested Scenarios:**
**1.** Tested latest build with 10.0.7 AppScan Source installed (which has product and IBM JRE changes) working as expected
**2.** Ran against AppScan Source 10.0.6 or earlier version also in which the install path is IBM to make sure latest changes works fine with the old version of source.
